### PR TITLE
Change State Code 40 to Oklahoma

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -239,7 +239,7 @@ var ParticipateStateCodes = map[int]string{
 	37: "North Carolina",
 	38: "North Dakota",
 	39: "Ohio",
-	40: "Ohio",
+	40: "Oklahoma",
 	45: "South Carolina",
 	55: "Wisconsin",
 }


### PR DESCRIPTION
According to [Publication 1220](https://www.irs.gov/pub/irs-pdf/p1220.pdf), CF/SF code 40 refers to Oklahoma, not Ohio. This PR only changes this mapping value.