### PR TITLE
Refactor validatePaymentCodes() (#289)

### DIFF
--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"encoding/json"
+
 	"gopkg.in/check.v1"
 
 	PDF "github.com/moov-io/irs/pkg/pdf_generator"
@@ -122,6 +123,7 @@ func (t *FileTest) TestParseFailed(c *check.C) {
 	person = &paymentPerson{}
 	c.Assert(person.validateRecords(), check.NotNil)
 	c.Assert(person.validatePaymentCodes(), check.NotNil)
+	c.Assert(person.validateAmounts(), check.NotNil)
 	c.Assert(person.integrationCheck(), check.NotNil)
 	_, err = person.getTypeOfReturn()
 	c.Assert(err, check.NotNil)
@@ -226,17 +228,22 @@ func (t *FileTest) TestPersonErrorCases(c *check.C) {
 	kRecord, ok := person.States[0].(*records.KRecord)
 	c.Assert(ok, check.Equals, true)
 	kRecord.ControlTotal7 = 1
-	c.Assert(person.validatePaymentCodes(), check.NotNil)
+	c.Assert(person.validatePaymentCodes(), check.IsNil)
+	c.Assert(person.validateAmounts(), check.IsNil)
 	kRecord.ControlTotal8 = 1
 	c.Assert(person.validatePaymentCodes(), check.NotNil)
+	c.Assert(person.validateAmounts(), check.IsNil)
 	person.States = append(person.States, records.NewCRecord())
 	c.Assert(person.validatePaymentCodes(), check.NotNil)
+	c.Assert(person.validateAmounts(), check.NotNil)
 	bRecord, ok := person.Payees[0].(*records.BRecord)
 	c.Assert(ok, check.Equals, true)
 	bRecord.PaymentAmount2 = 1
 	c.Assert(person.validatePaymentCodes(), check.NotNil)
+	c.Assert(person.validateAmounts(), check.NotNil)
 	person.Payees = append(person.Payees, records.NewCRecord())
 	c.Assert(person.validatePaymentCodes(), check.NotNil)
+	c.Assert(person.validateAmounts(), check.NotNil)
 	c.Assert(person.integrationCheck(), check.NotNil)
 }
 


### PR DESCRIPTION
This PR splits payment‑code checks from amount‑reconciliation logic and implements the revised business rules proposed in issue  #289.

**What changed**
- Refactored validatePaymentCodes() to: 
  - Only check payment code relationships
  - Remove all amount total logic
- Added new function validateAmounts() to:
  - Verify that Σ B == Σ C
  - Ensure Σ K ≤ Σ C
- Introduced helper functions for cleaner set logic:
  - toSet(), merge(), subset(), equal()
- Replaced rigid matching rules with updated logic:
  - B ⊆ A (every B-record code must exist in A)
  - C = ∪ B (C-record codes must match union of all B-records)
  - K ⊆ A (each K-record's codes must exist in A, no union match required)
- Updated test assertions to reflect new validation boundaries:
  - Added calls to validateAmounts() in FileTest
  - Adjusted expectations for valid and invalid edge cases
  - Updated integrationCheck() to include validateAmounts() call

**Why the changes were made**
- Legitimate files that omit unused codes in B/K records now pass
- Payment-code validation and amount reconciliation are independent, readable, and easier to maintain
- K records may not report only state-required amounts without triggering false errors

**Testing**
- Updated TestParseFailed and TestPersonErrorCases to reflect new changes
- All other existing tests passed